### PR TITLE
Add check service principal expiry on Azure

### DIFF
--- a/.github/workflows/check_sp.yml
+++ b/.github/workflows/check_sp.yml
@@ -1,0 +1,72 @@
+name: Check Service Principal
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "35 6 * * *"
+
+jobs:
+  set-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      tests: ${{ steps.select-tests.outputs.tests }}
+    steps:
+      - name: Select Tests
+        id: select-tests
+        run: |
+          d="{'environment' :'dev'          , 'principal': 's165d01-keyvault-readonly-access'}"
+          t="{'environment' :'test'          , 'principal': 's165t01-keyvault-readonly-access'}"
+          pp="{'environment' :'preprod'          , 'principal': 's165t01-preprod-keyvault-readonly-access'}"
+          p="{'environment' :'prod'         , 'principal': 's165p01-keyvault-readonly-access'}"
+          tests="{ 'data':[ ${d} ,  ${t} ,  ${pp} ,  ${p} ]}"
+          echo "::set-output name=tests::${tests}"
+  check_expires:
+    name:      ${{matrix.data.environment}}/${{ matrix.data.principal }}
+    needs:     set-matrix
+    strategy:
+       matrix: ${{ fromJson(needs.set-matrix.outputs.tests) }}
+    environment:
+         name: ${{ matrix.data.environment }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check ${{ steps.serviceprincipal.outputs.name }}
+        uses: DFE-Digital/github-actions/CheckServicePrincipal@master
+        id: pwsh_check_expire
+        with:
+            AzureCredentials: ${{ secrets.AZURE_CREDENTIALS }}
+            ServicePrincipal: ${{ matrix.data.principal }}
+            ExpiresWithinDays: 30
+
+      - name: Processing ${{fromJson(steps.pwsh_check_expire.outputs.json_data).data.Name}}
+        run:  echo Expires in ${{fromJson(steps.pwsh_check_expire.outputs.json_data).data.ExpiresDays}} days
+
+      - name: Check out the repo
+        if:   fromJson(steps.pwsh_check_expire.outputs.json_data).data.Application != 'Dummy'
+        uses: actions/checkout@v3
+
+      - uses: Azure/login@v1
+        if:   fromJson(steps.pwsh_check_expire.outputs.json_data).data.Application != 'Dummy'
+        with:
+            creds: ${{ secrets.AZURE_CREDENTIALS }}
+
+      - uses: DfE-Digital/keyvault-yaml-secret@v1
+        if:   fromJson(steps.pwsh_check_expire.outputs.json_data).data.Application != 'Dummy'
+        id:  keyvault-yaml-secret
+        with:
+          keyvault: ${{ secrets.KEY_VAULT}}
+          secret: MONITORING
+          key: SLACK_WEBHOOK
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+
+      - name: Slack Notification
+        if:   fromJson(steps.pwsh_check_expire.outputs.json_data).data.Application != 'Dummy'
+        uses: rtCamp/action-slack-notify@master
+        env:
+           SLACK_COLOR: '#ff0000'
+           SLACK_TITLE: ${{ fromJson(steps.pwsh_check_expire.outputs.json_data).data.Application }} ${{ fromJson(steps.pwsh_check_expire.outputs.json_data).data.Name }}
+           SLACK_MESSAGE: |
+                         The Service Principal ${{ fromJson(steps.pwsh_check_expire.outputs.json_data).data.Application }}
+                         key ${{ fromJson(steps.pwsh_check_expire.outputs.json_data).data.Name }} is due to expire in ${{fromJson(steps.pwsh_check_expire.outputs.json_data).data.ExpiresDays}} days
+                         Please follow the process in https://dfe-technical-guidance.london.cloudapps.digital/how-to/security/managing-secrets/#access-key-expiration to renew.
+           SLACK_WEBHOOK: ${{ steps.keyvault-yaml-secret.outputs.SLACK_WEBHOOK }}


### PR DESCRIPTION
### Context

Automated pipeline to check azure app registration secret expiry and 
notify through Slack. This will enable engineers to foresee which secrets 
are going to expire in advance. This allows non-disruptive running of 
deployments using the service connections from Github.

### Trello Card

https://trello.com/c/YPUTLdjS