### PR TITLE
Add automated removal of SpaceDevelopers role

### DIFF
--- a/.github/workflows/check_users_in_space_developer-role.yml
+++ b/.github/workflows/check_users_in_space_developer-role.yml
@@ -1,0 +1,65 @@
+name: Check users with space developer role
+
+on:
+  workflow_dispatch:
+  schedule: # Midnight every day
+    - cron: '0 0 * * *'
+
+
+jobs:
+  CHECK-SPACE-USER:
+    runs-on: ubuntu-latest
+    environment: prod
+
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v2
+
+      - uses: Azure/login@v1
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+
+      - name: Set environment variables
+        shell: bash
+        run: |
+          tf_vars_file=terraform/workspace_variables/prod.tfvars.json
+          echo "KEY_VAULT_NAME=$(jq -r '.key_vault_name' ${tf_vars_file})" >> $GITHUB_ENV
+          echo "PAAS_SPACE=$(jq -r '.paas_space' ${tf_vars_file})" >> $GITHUB_ENV
+
+      - uses: Azure/get-keyvault-secrets@v1
+        id: get_secrets
+        with:
+          keyvault: ${{ env.KEY_VAULT_NAME }}
+          secrets: 'PAAS-USER,PAAS-PASSWORD'
+
+      - uses: DfE-Digital/keyvault-yaml-secret@v1
+        id:  keyvault-yaml-secret
+        with:
+          keyvault: ${{ env.KEY_VAULT_NAME }}
+          secret: MONITORING
+          key: SLACK_WEBHOOK
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+
+      - uses: DFE-Digital/github-actions/setup-cf-cli@master
+        with:
+          CF_USERNAME: ${{ steps.get_secrets.outputs.PAAS-USER }}
+          CF_PASSWORD: ${{ steps.get_secrets.outputs.PAAS-PASSWORD }}
+          CF_SPACE_NAME: ${{ env.PAAS_SPACE }}
+          CF_ORG_NAME: dfe
+          CF_API_URL:  https://api.london.cloud.service.gov.uk
+          INSTALL_CONDUIT: false
+
+      - name: Checkout Repo
+        uses: actions/checkout@v3
+        with:
+          repository: DFE-Digital/bat-infrastructure
+          path: ./remote-checkout
+
+      - name: Run powershell script
+        run: |
+          ./remote-checkout/scripts/check-users-in-space-developer-role.ps1 \
+            -space "${{ env.PAAS_SPACE }}" \
+            -slack_webhook "${{ steps.keyvault-yaml-secret.outputs.SLACK_WEBHOOK }}" \
+            -unset true \
+            -whitelist "${{ steps.get_secrets.outputs.PAAS-USER }}"


### PR DESCRIPTION

### Context

Automated removal of SpaceDeveloper role in GOV PaaS **tra-production** space is required to remove any permanent access by users each day. Only service account should have this access permanently.

### Trello card

https://trello.com/c/axJFXcr0 