### PR TITLE
Alerting enabled on postgres service

### DIFF
--- a/terraform/monitoring.tf
+++ b/terraform/monitoring.tf
@@ -14,4 +14,6 @@ module "prometheus_all" {
   grafana_google_client_id     = local.secrets.GRAFANA_GOOGLE_CLIENT_ID
   grafana_google_client_secret = local.secrets.GRAFANA_GOOGLE_CLIENT_SECRET
   grafana_json_dashboards      = [file("dashboards/dqt_http_requests.json")]
+  alertable_postgres_services  = var.alertable_postgres_services
+  postgres_dashboard_url       = var.postgres_dashboard_url
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -15,3 +15,7 @@ variable "monitor_scrape_applications" {
 }
 variable "monitor_scrape_backing_services" {}
 variable "redis_services" {}
+variable "alertable_postgres_services" {
+  default = {}
+}
+variable "postgres_dashboard_url" { default = "" }

--- a/terraform/workspace_variables/dev.tfvars.json
+++ b/terraform/workspace_variables/dev.tfvars.json
@@ -9,9 +9,17 @@
 
   ],
   "monitor_scrape_backing_services": [
-    "tra-dev/qualified-teachers-api-dev-pg-svc"
+    "tra-dev/qualified-teachers-api-dev-pg-svc",
+    "tra-dev/find-a-lost-trn-dev-pg-svc"
   ],
   "redis_services": [
     "tra-dev/qualified-teachers-api-dev-redis-svc"
-  ]
+  ],
+  "postgres_dashboard_url": "https://grafana-tra-monitoring-dev.london.cloudapps.digital/d/a2FR6FUMz",
+  "alertable_postgres_services": {
+    "tra-dev/qualified-teachers-api-dev-pg-svc": {
+    },
+    "tra-dev/find-a-lost-trn-dev-pg-svc": {
+    }
+  }
 }

--- a/terraform/workspace_variables/prod.tfvars.json
+++ b/terraform/workspace_variables/prod.tfvars.json
@@ -8,9 +8,17 @@
       "qualified-teachers-api-prod.apps.internal:80"
     ],
     "monitor_scrape_backing_services": [
-      "tra-production/qualified-teachers-api-prod-pg-svc"
+      "tra-production/qualified-teachers-api-prod-pg-svc",
+      "tra-production/find-a-lost-trn-production-pg-svc"
     ],
     "redis_services": [
       "tra-production/qualified-teachers-api-prod-redis-svc"
-    ]
+    ],
+    "postgres_dashboard_url": "https://grafana-tra-monitoring-prod.london.cloudapps.digital/d/a2FR6FUMz",
+    "alertable_postgres_services": {
+      "tra-production/qualified-teachers-api-prod-pg-svc": {
+      },
+      "tra-production/find-a-lost-trn-production-pg-svc": {
+      }
+    }
 }


### PR DESCRIPTION
Enabled alerting on postgres service of DQT and Find-a-lost-TRN apis.

[x][Attached to trello](https://trello.com/c/YfXCgQ05/432-alerting-on-postgres-memory-cpu-limit)