### PR TITLE
Pause response time threshold for DQT API app

### DIFF
--- a/terraform/workspace_variables/prod.tfvars.json
+++ b/terraform/workspace_variables/prod.tfvars.json
@@ -25,9 +25,9 @@
   },
   "alertable_apps": {
     "tra-production/find-a-lost-trn-production": {},
-    "tra-production/qualified-teachers-api-prod": {
-      "response_threshold": 5
-    },
+    // "tra-production/qualified-teachers-api-prod": {
+    //   "response_threshold": 5
+    // },
     "tra-production/apply-for-qts-in-england-production": {}
   },
   "apps_dashboard_url": "https://grafana-tra-monitoring-prod.london.cloudapps.digital/d/eF19g4RZx"


### PR DESCRIPTION
### Context

DQT CRM is very slow, hence the DQT API call response time. This alert causes pollution in the Slack channel. This commit temporarily pauses the response time alert until we have good response time from CRM.