### PR TITLE
Remove response threshold for DQT API

### DIFF
--- a/terraform/workspace_variables/prod.tfvars.json
+++ b/terraform/workspace_variables/prod.tfvars.json
@@ -25,9 +25,6 @@
   },
   "alertable_apps": {
     "tra-production/find-a-lost-trn-production": {},
-    // "tra-production/qualified-teachers-api-prod": {
-    //   "response_threshold": 5
-    // },
     "tra-production/apply-for-qts-in-england-production": {}
   },
   "apps_dashboard_url": "https://grafana-tra-monitoring-prod.london.cloudapps.digital/d/eF19g4RZx"


### PR DESCRIPTION
### Context

JSON cannot contain commented code. This commit removes the response threshold alert for DQT API due to slow CRM response time.